### PR TITLE
:sparkles: add elements to subscribe to netlify oss plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![CircleCI](https://circleci.com/gh/zenika-open-source/insights-website/tree/master.svg?style=svg)](https://circleci.com/gh/zenika-open-source/insights-website/tree/master)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/44effe10-3635-426d-899d-984201fa828a/deploy-status)](https://app.netlify.com/sites/zenika-open-source-insights/deploys)
+
 # insights-website
+
 White label website to display awesome insights about organisation open source activity
 
 ## Install
@@ -12,4 +17,3 @@ yarn
 ```
 yarn start
 ```
-

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -620,3 +620,12 @@ pre tt:after {
     font-size: 100%;
   }
 }
+.partners {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+.copyright {
+  width: 100%;
+  text-align: center;
+}

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -5,12 +5,12 @@
  * See: https://www.gatsbyjs.org/docs/static-query/
  */
 
-import React from "react"
-import PropTypes from "prop-types"
-import { StaticQuery, graphql } from "gatsby"
+import React from "react";
+import PropTypes from "prop-types";
+import { StaticQuery, graphql } from "gatsby";
 
-import Header from "./header"
-import "./layout.css"
+import Header from "./header";
+import "./layout.css";
 
 const Layout = ({ children }) => (
   <StaticQuery
@@ -31,23 +31,34 @@ const Layout = ({ children }) => (
             margin: `0 auto`,
             maxWidth: 960,
             padding: `0px 1.0875rem 1.45rem`,
-            paddingTop: 0,
+            paddingTop: 0
           }}
         >
           <main>{children}</main>
           <footer>
-            © {new Date().getFullYear()}, Built with
-            {` `}
-            <a href="https://www.gatsbyjs.org">Gatsby</a>
+            <div class="partners">
+              <div>
+                <a href="https://www.netlify.com">
+                  <img
+                    alt="Deploys by Netlify"
+                    src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg"
+                  />
+                </a>
+              </div>
+            </div>
+            <div class="copyright">
+              © {new Date().getFullYear()}, Built with{" "}
+              <a href="https://www.gatsbyjs.org">Gatsby</a>
+            </div>
           </footer>
         </div>
       </>
     )}
   />
-)
+);
 
 Layout.propTypes = {
-  children: PropTypes.node.isRequired,
-}
+  children: PropTypes.node.isRequired
+};
 
-export default Layout
+export default Layout;


### PR DESCRIPTION
This is related to issue #20. It add all elements in order to subscribe to oss plan of netlify.

There is not linter/prettier yet, please don't look at code style. Also we have not defined a style chart yet so don't look at style for now. We will se that later for dedicated task.

This code will allow us to contact netlify to subscribe their oss plan.