### PR TITLE
:construction_worker: separate netlify and circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,39 +23,32 @@ jobs:
           root: .
           paths: .
 
-  build:
+  check-prettier:
     executor: default-executor
     steps:
       - attach_workspace:
           at: .
       - run:
-          name: "Build"
-          command: yarn build
-      - persist_to_workspace:
-          root: .
-          paths: public
+          name: "Check prettier"
+          command: echo 'Fake prettier check'
 
-  deploy:
+  check-linter:
     executor: default-executor
     steps:
       - attach_workspace:
           at: .
       - run:
-          name: "Netlify deploy"
-          command: yarn deploy
+          name: "Check linter"
+          command: echo 'Fake linter check'
 
 workflows:
   version: 2
-  build-and-deploy:
+  quality-checks:
     jobs:
       - install-dependencies
-      - build:
+      - check-prettier:
           requires:
             - install-dependencies
-      - deploy:
-          filters:
-            branches:
-              only:
-                - master
+      - check-linter:
           requires:
-            - build
+            - install-dependencies

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CircleCI](https://circleci.com/gh/zenika-open-source/insights-website/tree/master.svg?style=svg)](https://circleci.com/gh/zenika-open-source/insights-website/tree/master)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/44effe10-3635-426d-899d-984201fa828a/deploy-status)](https://app.netlify.com/sites/zenika-open-source-insights/deploys)
 
 # insights-website
 


### PR DESCRIPTION
This PR is about my last slack message :

> Hi ! I am still studying the subject to make a good CI/CD platform for insights.
> 
> I am a little bit desapointed about Netlify. For short, by default Netlify build and deploy automatically code that is pushed on production branch (aka "master"). There is no elegant way to avoid that. (see https://www.netlify.com/docs/continuous-deployment/#skipping-a-deploy for more information)
> 
> In order to avoid that automatic production build, I made a configuration to tell to Netlify that our production branch is 'null' which is actually a branch that does not exist. CircleCI build and deploy manually and therefore I am sure that what is builded passes quality check processed by CircleCI.
> 
> Honestly it sounds like a hack and not suit well with Netlify's philosophy. I suggest another workflow which sounds better for our case because our application is simple.
> 
> How could responsability be separated ?
> - *CircleCI* should check the quality of code (indentation, tests, bundle-size etc...)
> - *Netlify* should build and deploy
> 
> No PR/MR should be merged into master if both CircleCI and Netlify are not validated. It is important because Netlify automatically build and deploy !

I let Netlify make the build and CircleCI make quality checks. I put fake check for the next PRs about quality checks.