### PR TITLE
👷 Add bundlesize

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -1,0 +1,7 @@
+{
+  "files": [
+    {
+      "path": "public/*.js"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-helmet": "^5.2.0"
   },
   "devDependencies": {
+    "bundlesize": "^0.18.0",
     "netlify-cli": "^2.10.0",
     "pre-commit": "^1.2.2",
     "prettier": "^1.16.4"
@@ -41,8 +42,9 @@
     "format:fix": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
-    "deploy": "netlify deploy --prod"
+    "test": "yarn test:bundlesize",
+    "deploy": "netlify deploy --prod",
+    "test:  ": "bundlesize"
   },
   "pre-commit": "format:check",
   "repository": {


### PR DESCRIPTION
I've also added Bundlesize's environment variable on Circle CI, this way, we should get a status display for each PR.

So far, bundlesize only displays the bundle's size and **no maximum size has been set**.

A discussion about this matter has been started here: https://github.com/zenika-open-source/insights-website/issues/39