### PR TITLE
feat: change revalidation to dynamic fetching for contributors

### DIFF
--- a/src/app/contributors/page.tsx
+++ b/src/app/contributors/page.tsx
@@ -67,8 +67,8 @@ const getContributors = async (): Promise<Contributor[]> => {
   );
 };
 
-// Revalidate every 30 minutes (1800 seconds)
-export const revalidate = 1800;
+// Force the page to be dynamic to always fetch the latest contributors
+export const dynamic = 'force-dynamic';
 
 export default async function ContributorsPage() {
   const contributors = await getContributors();


### PR DESCRIPTION
This pull request makes a small change to the contributors page to ensure it always displays the most up-to-date contributor information by forcing the page to be dynamic.